### PR TITLE
openapi-spec-validator 0.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.9" %}
+{% set version = "0.4.0" %}
 
 package:
   name: openapi-spec-validator
@@ -7,7 +7,7 @@ package:
 source:
   fn: {{ version }}.tar.gz
   url: https://github.com/p1c2u/openapi-spec-validator/archive/{{ version }}.tar.gz
-  sha256: f004bc1133b4c1ba1bc49577bf454be5e1bcc7ea64b21b7a112678da6577d35a
+  sha256: 8042d76a4246026abb31a7c02a4c4a3c46f10de3a1998940069e8803f00f04ef
 
 build:
   noarch: python


### PR DESCRIPTION
Update openapi-spec-validator to 0.4.0