### PR TITLE
Update 0.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - openapi-schema-validator >=0.6.0,<0.7.0
     - importlib-resources >=5.8,<7.0  # [py<39]
     - jsonschema-path >=0.3.1,<0.4.0
-    - lazy-object-proxy >=1.7.1
+    - lazy-object-proxy >=1.7.1,<2
     - python
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9d7201cbef1e584f7323c96dc3e45d1a8d1f387a5b0ed808948e094fee328ee2
 
 build:
-  noarch: python
+  skip: true  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
@@ -20,7 +20,7 @@ requirements:
   host:
     - pip
     - poetry-core >=1.0.0
-    - python >=3.8.0
+    - python
 
   run:
     # keep in sync with the poetry-generated setup.py
@@ -31,12 +31,16 @@ requirements:
     - openapi-schema-validator
     - python
 test:
+  source_files:
+    - tests
   requires:
     - pip
+    - pytest
   imports:
     - openapi_spec_validator
   commands:
     - pip check
+    - pytest -vv
     - openapi-spec-validator --help
 
 
@@ -47,6 +51,7 @@ about:
   license_family: APACHE
   license_file: LICENSE
   dev_url: https://github.com/p1c2u/openapi-spec-validator
+  doc_url: https://openapi-spec-validator.readthedocs.io/en/latest/
   description: |-
     OpenAPI Spec Validator is a Python library that validates OpenAPI Specs
     against the OpenAPI 2.0 (aka Swagger) and OpenAPI 3.0 specification. The

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - openapi-schema-validator >=0.6.0,<0.7.0
     - importlib-resources >=5.8,<7.0  # [py<39]
     - jsonschema-path >=0.3.1,<0.4.0
-    - lazy-object-proxy >=1.7.1,<2.0.0
+    - lazy-object-proxy >=1.7.1
     - python
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     # keep in sync with the poetry-generated setup.py
     - jsonschema >=4.18.0,<5.0.0
     - openapi-schema-validator >=0.6.0,<0.7.0
-    - python >=3.8.0,<4.0.0
     - importlib-resources >=5.8,<7.0  # [py<39]
     - jsonschema-path >=0.3.1,<0.4.0
     - lazy-object-proxy >=1.7.1,<2.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - python
 
   run:
-    # keep in sync with the poetry-generated setup.py
     - jsonschema >=4.18.0,<5.0.0
     - openapi-schema-validator >=0.6.0,<0.7.0
     - importlib-resources >=5.8,<7.0  # [py<39]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.9" %}
+{% set version = "0.7.1" %}
 
 package:
   name: openapi-spec-validator
@@ -7,41 +7,50 @@ package:
 source:
   fn: {{ version }}.tar.gz
   url: https://github.com/p1c2u/openapi-spec-validator/archive/{{ version }}.tar.gz
-  sha256: f004bc1133b4c1ba1bc49577bf454be5e1bcc7ea64b21b7a112678da6577d35a
+  sha256: 9d7201cbef1e584f7323c96dc3e45d1a8d1f387a5b0ed808948e094fee328ee2
 
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - openapi-spec-validator = openapi_spec_validator.__main__:main
 
 requirements:
   host:
     - pip
-    - python
-    - setuptools
-    - pyyaml
+    - poetry-core >=1.0.0
+    - python >=3.8.0
 
   run:
+    # keep in sync with the poetry-generated setup.py
+    - importlib_resources 
+    - jsonschema 
+    - jsonschema-path 
+    - lazy-object-proxy 
+    - openapi-schema-validator
     - python
-    - jsonschema
-    - six
-    - setuptools
-    - pyyaml
-    - pathlib2
-
 test:
+  requires:
+    - pip
   imports:
     - openapi_spec_validator
+  commands:
+    - pip check
+    - openapi-spec-validator --help
+
 
 about:
   home: https://github.com/p1c2u/openapi-spec-validator
   license: Apache-2.0
-  summary: OpenAPI Spec validator
+  summary: OpenAPI 2.0 (aka Swagger) and OpenAPI 3 spec validator
   license_family: APACHE
   license_file: LICENSE
   dev_url: https://github.com/p1c2u/openapi-spec-validator
+  description: |-
+    OpenAPI Spec Validator is a Python library that validates OpenAPI Specs
+    against the OpenAPI 2.0 (aka Swagger) and OpenAPI 3.0 specification. The
+    validator aims to check for full compliance with the Specification.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,11 +24,12 @@ requirements:
 
   run:
     # keep in sync with the poetry-generated setup.py
-    - importlib_resources 
-    - jsonschema 
-    - jsonschema-path 
-    - lazy-object-proxy 
-    - openapi-schema-validator
+    - jsonschema >=4.18.0,<5.0.0
+    - openapi-schema-validator >=0.6.0,<0.7.0
+    - python >=3.8.0,<4.0.0
+    - importlib-resources >=5.8,<7.0  # [py<39]
+    - jsonschema-path >=0.3.1,<0.4.0
+    - lazy-object-proxy >=1.7.1,<2.0.0
     - python
 test:
   source_files:


### PR DESCRIPTION
openapi-spec-validator 0.7.1 

**Destination channel:** defaults

### Links

- [PKG-4452](https://anaconda.atlassian.net/browse/PKG-4452) 
- [Upstream repository](https://github.com/p1c2u/openapi-spec-validator)
- [Upstream changelog/diff](https://github.com/python-openapi/openapi-spec-validator/releases/tag/0.7.1)
- Relevant dependency PRs:
  - moto

### Explanation of changes:
- Update version, remove noarch, improve testing, pass lint


[PKG-4452]: https://anaconda.atlassian.net/browse/PKG-4452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ